### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 该高德地图 MCP Server 发布在 [PyPI](https://pypi.org/project/amap-mcp-server/)。
 
+<a href="https://glama.ai/mcp/servers/@sugarforever/amap-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@sugarforever/amap-mcp-server/badge" alt="高德地图 MCP server" />
+</a>
+
 ## MCP 工具列表
 
 本服务提供以下工具：


### PR DESCRIPTION
This PR adds a badge for the [高德地图](https://glama.ai/mcp/servers/@sugarforever/amap-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@sugarforever/amap-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@sugarforever/amap-mcp-server/badge" alt="高德地图 MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.