### PR TITLE
fix: remove stray print(data) that corrupts stdio protocol

### DIFF
--- a/amap_mcp_server/server.py
+++ b/amap_mcp_server/server.py
@@ -560,7 +560,7 @@ def maps_direction_transit_integrated_by_coordinates(origin: str, destination: s
         response.raise_for_status()
         data = response.json()
 
-        print(data)
+        
         if data.get("status") != "1":
             return {"error": f"Direction Transit Integrated failed: {data.get('info') or data.get('infocode')}"}
 


### PR DESCRIPTION
`maps_direction_transit_integrated_by_coordinates` prints the raw response dict to stdout. For stdio MCP that pollutes the JSON-RPC channel, causing transit requests to hang forever.

This removes the leftover debug print so transit planning works via stdio.